### PR TITLE
Move examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ currently supported for message decoding.
 
 ## The Examples
 
-There are two example programs in `src/examples`. One sends an OSC
+There are two example programs in `examples`. One sends an OSC
 message, the other waits for incoming OSC messages and when it
 receives them it prints out the message address and arguments. By
 default the programs will work together, so that if you are running
@@ -44,8 +44,8 @@ code of the Chuck programming language.
 From the directory where you checked out `osc-pony`, run:
 
 ```
-ponyc src/examples/receive/
-ponyc src/send/send/
+ponyc examples/receive/
+ponyc send/send/
 ```
 
 Now, in one terminal window run the `receive` program:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Address: /sndbuf/buf/rate
 To create an OSC message with integer, float, and string arguments with the address `/my/address`:
 
 ```
-  let message = OSCMessage('/my/address', recover [as OSCData: OSCInt(42), OSCFloat(3.14159), OSCString("this is a string")] end)
+  let message = OSCMessage('/my/address', 
+    recover [as OSCData: OSCInt(42), OSCFloat(3.14159), 
+      OSCString("this is astring")] 
+    end)
   let bytes = message.to_bytes()
 
   // now do something with these bytes ...

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To create an OSC message with integer, float, and string arguments with the addr
 ```
   let message = OSCMessage('/my/address', 
     recover [as OSCData: OSCInt(42), OSCFloat(3.14159), 
-      OSCString("this is astring")] 
+      OSCString("this is a string")] 
     end)
   let bytes = message.to_bytes()
 

--- a/examples/receive/receive.pony
+++ b/examples/receive/receive.pony
@@ -6,7 +6,7 @@ be found in `examples/osc/OSC_send.ck` when you download the Chuck
 source code.
 """
 
-use "../../osc-pony"
+use "../src/osc-pony"
 
 use "net"
 

--- a/examples/send/send.pony
+++ b/examples/send/send.pony
@@ -6,7 +6,7 @@ be found in `examples/osc/OSC_recv.ck` when you download the Chuck
 source code.
 """
 
-use "../../osc-pony"
+use "../src/osc-pony"
 
 use "net"
 
@@ -38,7 +38,7 @@ actor Main
 
     let message = OSCMessage("/sndbuf/buf/rate", recover [as OSCData val: OSCFloat(0.2)] end)
     try
-      let auth = env.root as AmbientAuth 
+      let auth = env.root as AmbientAuth
       let destination = DNS.ip4(auth, host, port)(0)
       UDPSocket(auth, UDPClient(env, (consume destination), message))
     else


### PR DESCRIPTION
Based on how Pony's PONYPATH works, we want to move examples.
PONYPATH points at various top level directories that contain
Pony libraries. So for example, we could point at `osc-pony/src`
which would include anything in that as a possible package to include
in a pony program via `use "package"`. By having examples in `src`,
these waters get very muddied. `examples` isn't a package for inclusion
and therefore shouldn't be in the same directory as packages. For now,
move `examples` out. Although, having

src/
src/packages/
src/examples/

could also make sense
